### PR TITLE
Set ContentLength = 0 for requests with no body

### DIFF
--- a/DotNet/proxy.ashx
+++ b/DotNet/proxy.ashx
@@ -466,10 +466,15 @@ public class proxy : IHttpHandler {
             req.Method = "POST";
             req.ContentType = string.IsNullOrEmpty(contentType) ? "application/x-www-form-urlencoded" : contentType;
             if (bytes != null && bytes.Length > 0)
+            {
                 req.ContentLength = bytes.Length;
-            using (Stream outputStream = req.GetRequestStream()) {
-                outputStream.Write(bytes, 0, bytes.Length);
+                using (Stream outputStream = req.GetRequestStream())
+                {
+                    outputStream.Write(bytes, 0, bytes.Length);
+                }
             }
+            else
+                req.ContentLength = 0; 
         }
         return req.GetResponse();
     }


### PR DESCRIPTION
The remote server responds with error 411 Length Required when posting a request with no message-body. Setting ContentLength = 0 for the request fixes it.

I also moved the outputStream.Write code into the if block so it doesn't throw a null reference exception (which was not being handled by the using statement).